### PR TITLE
chore: support SnakeCasedName

### DIFF
--- a/convert/strings.go
+++ b/convert/strings.go
@@ -20,7 +20,11 @@ func MD5Hash(text string) string {
 // Note it may break if string and/or slice header will change
 // in the future go versions.
 func BytesToStr(b []byte) string {
-	/* #nosec G103 */
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+// RunesToStr converts rune slice to a string.
+func RunesToStr(b []rune) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
@@ -37,4 +41,21 @@ func StrToBytes(s string) (b []byte) {
 	bh.Len = sh.Len
 	bh.Cap = sh.Len
 	return b
+}
+
+// SnakeCasedName convert String into Snake Case
+// ex: FooBar -> foo_bar
+func SnakeCasedName(name string) string {
+	newstr := make([]rune, 0)
+	for idx, chr := range name {
+		if isUpper := 'A' <= chr && chr <= 'Z'; isUpper {
+			if idx > 0 {
+				newstr = append(newstr, '_')
+			}
+			chr -= ('A' - 'a')
+		}
+		newstr = append(newstr, chr)
+	}
+
+	return RunesToStr(newstr)
 }

--- a/convert/strings_benchmark_test.go
+++ b/convert/strings_benchmark_test.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -81,5 +82,40 @@ func BenchmarkConvertNew(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		k := StrToBytes(s)
 		_ = BytesToStr(k)
+	}
+}
+
+func BenchmarkSnakeCasedNameOld(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := "FooBar"
+		_ = SnakeCasedName(s)
+	}
+}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+func toSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+func BenchmarkToSnakeCasedName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		s := "FooBar"
+		_ = toSnakeCase(s)
+	}
+}
+
+func BenchmarkRunesToStrOld(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = string([]rune(s))
+	}
+}
+
+func BenchmarkRunesToStrNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RunesToStr([]rune(s))
 	}
 }


### PR DESCRIPTION
```
BenchmarkSnakeCasedNameOld-48    	30000000	       150 ns/op	      56 B/op	       3 allocs/op
BenchmarkToSnakeCasedName-48     	 2000000	      1865 ns/op	     121 B/op	       8 allocs/op
BenchmarkRunesToStrOld-48        	  300000	     14105 ns/op	    5248 B/op	       2 allocs/op
BenchmarkRunesToStrNew-48        	 2000000	      2309 ns/op	    4096 B/op	       1 allocs/op
```